### PR TITLE
Exclude stickler E999

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,4 +1,5 @@
 linters:
   flake8:
+    ignore: 'E999'
     max-line-length: 79
     fixer: false


### PR DESCRIPTION
Linter fails in some cases when certain features of Python 3 are used (e.g. print in specific cases).
Change proposal: ignore *E999 SyntaxError: invalid syntax*
Other errors and warnings will still be present. Please share your thoughts.